### PR TITLE
Add support for minimum_perl_version

### DIFF
--- a/lib/Software/Security/Policy/Individual.pm
+++ b/lib/Software/Security/Policy/Individual.pm
@@ -104,6 +104,10 @@ sub new {
   bless $arg => $class;
 }
 
+=method minimum_perl_version
+
+The minimum version of perl that is supported.
+
 =method perl_support_years
 
 Get the number of years for which past major versions of Perl would be
@@ -136,7 +140,9 @@ sub git_url { (defined $_[0]->{git_url} ? $_[0]->{git_url} :
                 'SECURITY.md')) }
 
 
-sub perl_support_years { (defined $_[0]->{perl_support_years} ? $_[0]->{perl_support_years} : '10') };
+sub perl_support_years { $_[0]->{perl_support_years} };
+
+sub minimum_perl_version { $_[0]->{minimum_perl_version} }
 
 sub timeframe {
     return $_[0]->{timeframe} if defined $_[0]->{timeframe};
@@ -264,6 +270,29 @@ Software::License.
 
 =cut
 
+sub _perl_supported_version_section {
+  my $self = shift;
+  my $program = $self->program;
+  if (my $minimum_perl_version = $self->minimum_perl_version) {
+    return <<EOF;
+
+Note that the $program project only supports major versions of Perl since
+$minimum_perl_version, even though $program will run on
+older versions of Perl. If a security fix requires us to increase
+the minimum version of Perl that is supported, then we may do so.
+EOF
+  } elsif (my $perl_support_years = $self->perl_support_years) {
+    return <<EOF
+
+Note that the $program project only supports major versions of Perl
+released in the past $perl_support_years years, even though $program will run on
+older versions of Perl.  If a security fix requires us to increase
+the minimum version of Perl that is supported, then we may do so.
+EOF
+  } else {
+    return '';
+  }
+}
 1;
 
 __DATA__
@@ -349,12 +378,7 @@ uses {{ $self->program }}, or plugins to it that are not included with the
 
 The maintainer(s) will only commit to releasing security fixes for
 the latest version of {{ $self->program }}.
-
-Note that the {{ $self->program }} project only supports major versions of Perl
-released in the past {{ $self->perl_support_years }} years, even though {{ $self->program }} will run on
-older versions of Perl.  If a security fix requires us to increase
-the minimum version of Perl that is supported, then we may do so.
-
+{{ $self->_perl_supported_version_section }}
 # Installation and Usage Issues
 
 The distribution metadata specifies minimum versions of

--- a/t/basic.t
+++ b/t/basic.t
@@ -24,6 +24,7 @@ like($policy->fulltext, qr(https://www.example.com/INDIVIDUAL-SECURITY-POLICY), 
 
 $policy = $class->new({
         maintainer  => 'X. Ample <x.example@example.com>',
+        perl_support_years   => '10',
     });
 
 is($policy->maintainer, 'X. Ample <x.example@example.com>', 'maintainer');


### PR DESCRIPTION
This adds a minimum_perl_version option. If neither it nor perl_support_years is given, it leaves out the relevant paragraph.