### PR TITLE
Add a security contact option

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 NAME
     Software::Security::Policy - packages that provide templated Security
-    Policys
+    Policies
 
 VERSION
     version 0.11
@@ -94,7 +94,7 @@ ACKNOWLEDGMENT
 SEE ALSO
     The specific policy:
 
-    Extra policys are maintained on CPAN in separate modules.
+    Extra policies are maintained on CPAN in separate modules.
 
 AUTHOR
     Timothy Legge <timlegge@gmail.com>

--- a/cpanfile
+++ b/cpanfile
@@ -21,4 +21,5 @@ on 'develop' => sub {
   requires "Test::NoTabs" => "0";
   requires "Test::Pod" => "1.41";
   requires "Test::Pod::Coverage" => "1.08";
+  requires "Test::Spelling" => "0.17";
 };

--- a/dist.ini
+++ b/dist.ini
@@ -64,6 +64,15 @@ web = https://github.com/CPAN-Security/Software-Security-Policy/issues
 [Test::EOL]
 [Test::EOF]
 [Test::NoTabs]
+[Test::PodSpelling]
+stopword = CPANSec
+stopword = GitLab
+stopword = Reddit
+stopword = triaging
+stopword = fulltext
+stopword = timeframe
+stopword = templated
+stopword = md
 
 [PodWeaver]
 [NextRelease]

--- a/lib/Software/Security/Policy/Individual.pm
+++ b/lib/Software/Security/Policy/Individual.pm
@@ -50,6 +50,22 @@ security policy class.  Valid arguments are:
 
 the current maintainer for the distribution; B<Required>
 
+if a security_contact is defined it will override the maintainer.
+
+Note that the B<report_url>, if defined, will override both the
+B<maintainer> and B<security_contact>
+
+=item security_contact
+
+the current security contact for the distribution; B<Optional>
+
+this will override the B<maintainer> and may be an option provided to
+Dist::Zilla::Plugin::SecurityPolicy if the authors are not the
+security contact.
+
+Note that the B<report_url>, if defined, will override both the
+B<maintainer> and B<security_contact>
+
 =item timeframe
 
 the time to expect acknowledgement of a security issue.  Should
@@ -80,6 +96,9 @@ a git url where the most current security policy can be found.
 =item report_url
 
 the URL where you can report security issues.
+
+The B<report_url>, if defined, will override both the B<maintainer>
+and B<security_contact> (if defined)
 
 =item perl_support_years
 
@@ -158,10 +177,14 @@ sub timeframe {
     return '5 days';
 }
 
-sub maintainer { $_[0]->{maintainer}     }
+sub maintainer {
+    defined $_[0]->{security_contact} ? $_[0]->{security_contact} : $_[0]->{maintainer}
+}
 
 sub _dotless_maintainer {
-  my $maintainer = $_[0]->maintainer;
+  my $maintainer = defined $_[0]->{security_contact} ?
+                        $_[0]->{security_contact} :
+                        $_[0]->maintainer;
   $maintainer =~ s/\.$//;
   return $maintainer;
 }

--- a/lib/Software/Security/Policy/Individual.pm
+++ b/lib/Software/Security/Policy/Individual.pm
@@ -77,13 +77,13 @@ Default: 5 days
 
 the amount of time to expect an acknowledgement of a security issue.
 Only used if timeframe is undefined and timeframe_units is defined
-(eg. '5')
+(e.g. '5')
 
 =item timeframe_units
 
 the units of time to expect an acknowledgement of a security issue.
 Only used if timeframe is undefined and timeframe_quantity is defined
-(eg. 'days')
+(e.g. 'days')
 
 =item url
 

--- a/t/security_contact.t
+++ b/t/security_contact.t
@@ -1,0 +1,30 @@
+#!perl
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+
+my $class = 'Software::Security::Policy::Individual';
+require_ok($class);
+
+my $policy = $class->new({
+        maintainer  => 'X. Ample <x.example@example.com>',
+        program     => 'Foo::Bar',
+        timeframe   => '6 days',
+        git_url     => 'https://example.com/xampl/Foo-Bar',
+        report_url  => 'https://example.com/xampl/Foo-Bar/security/advisories',
+        perl_support_years   => '8',
+        security_contact  => 'Security Contact X. Ample <sec_x.example@example.com>',
+    });
+
+is($policy->maintainer, 'Security Contact X. Ample <sec_x.example@example.com>', 'Security Contact matches');
+isnt($policy->maintainer, 'X. Ample <x.example@example.com>', 'Maintainer overridden properly');
+
+$policy = $class->new({
+        maintainer  => 'Security Contact X. Ample <sec_x.example@example.com>',
+        perl_support_years   => '10',
+    });
+
+is($policy->maintainer, 'Security Contact X. Ample <sec_x.example@example.com>', 'Security Contact matches');
+isnt($policy->maintainer, 'X. Ample <x.example@example.com>', 'Maintainer overridden properly');
+


### PR DESCRIPTION
I have noticed that having a security_contact option would be useful.  

Dist::Zilla::Plugin::SecurityPolicy could then specify:

```
[SecurityPolicy]
 -policy = Individual
 timeframe = 2 weeks
 security_contact = Security Contact X. Ample <sec_x.example@example.com>
```
 that would then overide the author(s)
